### PR TITLE
Quick hotfix for our app on iOS 12

### DIFF
--- a/LDOLayoutTemplates/Classes/LDOLayoutTemplate.m
+++ b/LDOLayoutTemplates/Classes/LDOLayoutTemplate.m
@@ -134,8 +134,9 @@
     for (UIView *view in views) {
         for (NSLayoutConstraint *constraint in view.constraints) {
             BOOL betweenViews = [views containsObject:constraint.firstItem] && [views containsObject:constraint.secondItem];
-            BOOL sizeConstraint = constraint.secondItem == nil
-                    && (constraint.firstAttribute == NSLayoutAttributeHeight || constraint.firstAttribute == NSLayoutAttributeWidth)
+            BOOL sizeConstraint = (constraint.firstAttribute == NSLayoutAttributeHeight || constraint.firstAttribute == NSLayoutAttributeWidth)
+                    && constraint.secondItem == nil
+                    && [views containsObject:constraint.firstItem]
                     && [constraint isMemberOfClass:[NSLayoutConstraint class]]
                     && ![constraint.identifier containsString:@"-Encapsulated-Layout-"];
             if (betweenViews || sizeConstraint) {


### PR DESCRIPTION
Without this condition, width/height constraints for UIScrollView's new layout guides would be collected into the array here. And because their `firstItem` is not a layout guide, and not a view that we know about, `+[LDOLayoutTemplate layoutTemplateForCurrentStateBasedOnTemplate:]` would then end up creating constraints with `firstItem == secondItem == nil`. iOS 12 raises an exception in this case.

Food for thought:
- Maybe we should actually collect constraints that involve these layout guides? The user might want to use and transfer these. But then we have to be careful not to transfer magic UIKit constraints.
  - Speaking of which, the "-Encapsulated-Layout-" check needs a comment 😇
- `+[LDOLayoutTemplate layoutTemplateForCurrentStateBasedOnTemplate:]` seems to expect that `firstItem` can be nil, but when would that ever be valid? Shouldn't we log and bail in this case?